### PR TITLE
Configure Gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# Install OpenJDK 11
+RUN  bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install java 11.0.2-open"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+    file: .gitpod.dockerfile
+ports:
+    - port: 8080
+      onOpen: open-preview
+tasks:
+    - init: |
+        ./mvnw clean package
+      command: |
+        ./mvnw spring-boot:run


### PR DESCRIPTION
Hi @odrotbohm!

following [your tweet](https://twitter.com/odrotbohm/status/1133642832395292672) I created this PR to show how to configure Java11 in Gitpod.

Also, this PR 
* configures Gitpod to run `mvnw clean package` either when you open a new workspace or even before opening the workspace (when the [Gitpod App](https://github.com/apps/gitpod-io) is installed on the repo).
* run `mvnw spring-boot:run` when a workspace opens
* Open a Preview Browser, when an application starts listening on port 8080.

To try it before merging, click on:
https://gitpod.io/#https://github.com/meysholdt/guestbook

and this is how it looks like:
* I can open Java files both form the workspaces and from inside the JARs
* the "Problems" View is empty: no errors/warnings.

![image](https://user-images.githubusercontent.com/239422/58555313-6b72f500-8219-11e9-9886-5aa8efcf8a00.png)
